### PR TITLE
Update LanguageExt.Core

### DIFF
--- a/api/api.csproj
+++ b/api/api.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="1.9.1" />
-    <PackageReference Include="LanguageExt.Core" Version="3.3.43" />
+    <PackageReference Include="LanguageExt.Core" Version="3.3.48" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.0" />


### PR DESCRIPTION
ref: https://github.com/louthy/language-ext/commit/a31bad880668c4cdf7934929d6cc2d9324379d3a

これでToEitherが

```cs
public static Task<Either<Exception, A>> ToEither<A>(this TryAsync<A> self) =>
```
から
```cs
public static EitherAsync<Error, A> ToEither<A>(this TryAsync<A> self) => 
```

になって、ErrorをExceptionにMapする必要が出たのでその辺りも修正